### PR TITLE
Improves performance of json_stream_parser.cc by factor 1000

### DIFF
--- a/src/google/protobuf/stubs/strutil.h
+++ b/src/google/protobuf/stubs/strutil.h
@@ -35,6 +35,7 @@
 
 #include <stdlib.h>
 #include <vector>
+#include <cstring>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/stringpiece.h>
 
@@ -116,6 +117,12 @@ inline bool HasPrefixString(const string& str,
                             const string& prefix) {
   return str.size() >= prefix.size() &&
          str.compare(0, prefix.size(), prefix) == 0;
+}
+  
+inline bool HasPrefixString(StringPiece str,
+                            StringPiece prefix) {
+  return str.size() >= prefix.size() &&
+  		 memcmp(str.data(), prefix.data(), prefix.size()) == 0;
 }
 
 inline string StripPrefixString(const string& str, const string& prefix) {


### PR DESCRIPTION
JsonStreamParser::GetNextTokenType() uses HasPrefixString a lot on StringPiece as input. For each call two std::strings are constructed, compared and destroyed. Parsing of json-files with 50-60 MB in debug mode takes minutes.
Inserting a HasPrefixString on StringPiece reduces the overhead strongly. 